### PR TITLE
Edit Page enable users to edit food items: success message when successfully edited and error message 

### DIFF
--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -83,7 +83,7 @@ function Edit() {
               />
             </div>
             <div>
-              <label>Food_Author</label>
+              <label>Food Author</label>
               <input
                 type="text"
                 name="author"

--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -58,6 +58,7 @@ function Edit() {
     } else {
       console.log(response);
       result.error = await response.text();
+      toast.error("Error Notification !");
     }
     return result;
   };

--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -67,13 +67,13 @@ function Edit() {
   };
 
   return (
-    <div>
+    <>
       <Container>
         <h1>Updated Food Items!</h1>
         <div>
           <form onSubmit={FormHandle}>
             <div>
-              <label>Title</label>
+              <label>Food_Title</label>
               <input
                 type="text"
                 name="title"
@@ -82,7 +82,7 @@ function Edit() {
               />
             </div>
             <div>
-              <label>Author</label>
+              <label>Food_Author</label>
               <input
                 type="text"
                 name="author"
@@ -91,7 +91,7 @@ function Edit() {
               />
             </div>
             <div>
-              <label>Image</label>
+              <label>Food_Image</label>
               <input
                 type="text"
                 name="img"
@@ -99,42 +99,58 @@ function Edit() {
                 onChange={onInputChange}
               />
             </div>
-            <div className="container text-center">
-              <Button variant="contained" type="submit">
-                Update Item
-              </Button>
-              <ToastContainer />
-              <div>
-                <Button
-                  variant="contained"
-                  color="success"
-                  onClick={navigateToEdit}
-                >
-                  Return To Details Page
-                </Button>
-              </div>
-            </div>
+            <Button variant="contained" type="submit">
+              Update Item
+            </Button>
+            <ToastContainer />
+            <Button
+              variant="contained"
+              color="success"
+              onClick={navigateToEdit}
+            >
+              Return To Details Page
+            </Button>
           </form>
         </div>
       </Container>
-    </div>
+    </>
   );
 }
 
 const Container = styled.div`
-  input{
-  font-size: 18px;
-  padding:10px;
-  margin: 10px;
-  background: white;
-  border: none;
-  border-radius: 3px;
-  ::placeholder {
+  label {
     color: black;
+    font-weight: bold;
+    display: block;
+    width: 150px;
+    float: left;
   }
 
-  h1{
-    text-align:center;
+  h1 {
+    text-align: center;
+    color: white;
+    margin-bottom: 50px;
+  }
+
+  Button {
+    display: block;
+    box-sizing: border-box;
+    border-radius: 4px;
+    padding: 20px;
+    justify-content: center;
+    color: #fff;
+    margin: 30px;
+    cursor: pointer;
+  }
+  input {
+    display: block;
+    box-sizing: border-box;
+    width: 20%;
+    border-radius: 4px;
+    border: 1px solid white;
+    padding: 28px 10px;
+    margin-bottom: 5px;
+    font-size: 14px;
   }
 `;
 export default Edit;

--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -6,33 +6,34 @@ import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
 function Edit() {
-  const [edited, setEdited] = useState(true);
   const navigate = useNavigate();
   const notify = () => toast("Successfully Updated!");
   const { id } = useParams();
   const [editFood, setEditFood] = useState({
-    foodName: "",
-    foodAuthor: "",
+    title: "",
+    author: "",
     img: "",
   });
 
   useEffect(() => {
     const editFoodId = async () => {
-      const response = await fetch(`http://localhost:5000/menu_item/${id}`); //change endpoint to hit 1 entry not all
+      const response = await fetch(`http://localhost:5000/menu_items/${id}`); //change endpoint to hit 1 entry not all
       const result = {
         data: null,
         error: null,
       };
-      console.log(result);
+
       if (response.ok) {
-        result.data = response.json();
+        result.data = await response.json();
       } else {
-        result.error = response.text();
+        result.error = await response.text();
       }
-      return result;
+      console.log(result.data);
+      setEditFood(result.data);
     };
 
-    editFoodId();
+    const foodResult = editFoodId();
+    console.log(foodResult);
   }, [id]);
 
   const onInputChange = (e) => {
@@ -54,6 +55,8 @@ function Edit() {
     };
     if (response.ok) {
       result.data = await response.json();
+      //this is where success happens yay!!!!!!!
+      //spot to trigger notify toast
     } else {
       console.log(response);
       result.error = await response.text();
@@ -72,25 +75,25 @@ function Edit() {
         <div>
           <form onSubmit={FormHandle}>
             <div>
-              <label>Food Name</label>
+              <label>Title</label>
               <input
                 type="text"
-                name="foodName"
-                value={editFood.foodName}
+                name="title"
+                value={editFood.title}
                 onChange={onInputChange}
               />
             </div>
             <div>
-              <label>Food Author</label>
+              <label>Author</label>
               <input
                 type="text"
-                name="foodAuthor"
-                value={editFood.foodAuthor}
+                name="author"
+                value={editFood.author}
                 onChange={onInputChange}
               />
             </div>
             <div>
-              <label>Food Image</label>
+              <label>Image</label>
               <input
                 type="text"
                 name="img"
@@ -99,42 +102,21 @@ function Edit() {
               />
             </div>
             <div className="container text-center">
-              {edited ? (
-                <>
-                  <Button
-                    variant="contained"
-                    type="submit"
-                    onClick={() => setEdited(!edited)}
-                    onClick={notify}
-                  >
-                    Updated Item
-                  </Button>
-                  <ToastContainer />
-                  <div>
-                    <Button
-                      variant="contained"
-                      type="submit"
-                      onClick={navigateToEdit}
-                    >
-                      Return To Details Page
-                    </Button>
-                  </div>
-                </>
-              ) : (
-                <div>
-                  <h1>Error Message</h1>
-                </div>
-              )}
+              <Button variant="contained" type="submit">
+                Update Item
+              </Button>
+              <ToastContainer />
+              <div>
+                <Button
+                  variant="contained"
+                  type="button"
+                  onClick={navigateToEdit}
+                >
+                  Return To Details Page
+                </Button>
+              </div>
             </div>
           </form>
-
-          <div className="cart">
-            <ul>
-              {/* {data.map((data) => (
-                <li key={id}>{title}</li>
-              ))} */}
-            </ul>
-          </div>
         </div>
       </Container>
     </div>

--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -92,7 +92,7 @@ function Edit() {
               />
             </div>
             <div>
-              <label>Food_Image</label>
+              <label>Food Image</label>
               <input
                 type="text"
                 name="img"

--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -108,7 +108,7 @@ function Edit() {
               color="success"
               onClick={navigateToEdit}
             >
-              Return To Details Page
+              Details Page
             </Button>
           </form>
         </div>

--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -74,7 +74,7 @@ function Edit() {
         <div>
           <form onSubmit={FormHandle}>
             <div>
-              <label>Food_Title</label>
+              <label>Food Title</label>
               <input
                 type="text"
                 name="title"

--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -7,7 +7,6 @@ import "react-toastify/dist/ReactToastify.css";
 
 function Edit() {
   const navigate = useNavigate();
-  const notify = () => toast("Successfully Updated!");
   const { id } = useParams();
   const [editFood, setEditFood] = useState({
     title: "",
@@ -55,8 +54,7 @@ function Edit() {
     };
     if (response.ok) {
       result.data = await response.json();
-      //this is where success happens yay!!!!!!!
-      //spot to trigger notify toast
+      toast.success("Success!");
     } else {
       console.log(response);
       result.error = await response.text();
@@ -109,7 +107,7 @@ function Edit() {
               <div>
                 <Button
                   variant="contained"
-                  type="button"
+                  color="success"
                   onClick={navigateToEdit}
                 >
                   Return To Details Page
@@ -135,11 +133,8 @@ const Container = styled.div`
     color: black;
   }
 
-  Button{
-    display:flex;
-   margin:30px;
-    padding: 40px;
-    border-radius: 10px;
+  h1{
+    text-align:center;
   }
 `;
 export default Edit;

--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -58,7 +58,7 @@ function Edit() {
     } else {
       console.log(response);
       result.error = await response.text();
-      toast.error("Error Notification !");
+      toast.error(`Food item not saved.  Error: ${result.error}`);
     }
     return result;
   };

--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -105,8 +105,7 @@ function Edit() {
             </Button>
             <ToastContainer />
             <Button
-              variant="contained"
-              color="success"
+              variant="outlined"
               onClick={navigateToEdit}
             >
               Details Page

--- a/server/index.js
+++ b/server/index.js
@@ -15,7 +15,7 @@ app.get("/menu_items", async (req, res) => {
 });
 
 //Add server endpoint to GET a single food item
-app.get("/menu_item/:id", async (req, res) => {
+app.get("/menu_items/:id", async (req, res) => {
   const { id } = req.params;
   const getFoodItem = await prisma.food.findUnique({
     where: {


### PR DESCRIPTION
Changed the single item path and now returning a single edited item

- [x]  Trigger the success toast on successful edit
- [x]  Trigger the error toast on error from the server
- [x]  Touch up the UI a bit, for example add some spacing between the buttons and make the label width consistent
- [x]  change the return to details button into a secondary button

<img width="972" alt="image" src="https://user-images.githubusercontent.com/34128735/211691254-a981b1d2-d36e-4c05-ba24-5de6852844d2.png">
