### PR TITLE
[UX] Update the after-edit UX of the edit page

### DIFF
--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -98,7 +98,7 @@ function Edit() {
             </Button>
             <ToastContainer />
             <Button variant="outlined" onClick={navigateToEdit}>
-              Details Page
+              Back To Menu
             </Button>
           </form>
         </div>


### PR DESCRIPTION

<img width="395" alt="Screen Shot 2023-02-01 at 12 35 22 PM" src="https://user-images.githubusercontent.com/34128735/216119515-2e4da1d0-c5b4-46f7-8c4e-09f3ab6f457e.png">
Updated the button that read `Details` page to now read `Back To Menu` for ease in usability 