### PR TITLE
Cloudinary Gravity URL for resizing images

### DIFF
--- a/client/src/pages/Details.js
+++ b/client/src/pages/Details.js
@@ -2,6 +2,7 @@ import React from "react";
 import axios from "axios";
 import { useQuery } from "react-query";
 import { useState } from "react";
+import { Image } from "cloudinary-react";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Layout from "../components/Layout";
@@ -39,7 +40,7 @@ function Details() {
 
   const generateImageURL = (img) => {
     return (
-      "https://res.cloudinary.com/dac1at79b/image/upload/c_fill,w_200/" + img
+      "https://res.cloudinary.com/dac1at79b/image/upload/c_fill,w_700/" + img
     );
   };
 
@@ -85,8 +86,8 @@ function Details() {
           {filteredMenuItems.map((data) => {
             return (
               <div key={data.id} style={{ display: "flex" }}>
-                <img src={generateImageURL(data)} alt="cloudinary" />
-                {/* <img src={data.img} alt="images" /> */}
+                <Image src={generateImageURL(data.img)} alt="cloudinary" />
+
                 <Box
                   className="boxMenu"
                   lg={{

--- a/client/src/pages/Details.js
+++ b/client/src/pages/Details.js
@@ -38,9 +38,10 @@ function Details() {
       });
 
   const generateImageURL = (img) => {
-    return `https://res.cloudinary.com/dac1at79b/image/upload/c_fill,w_200/`;
+    return (
+      "https://res.cloudinary.com/dac1at79b/image/upload/c_fill,w_200/" + img
+    );
   };
-  console.log(generateImageURL());
 
   const handleDelete = async (id) => {
     try {
@@ -84,7 +85,7 @@ function Details() {
           {filteredMenuItems.map((data) => {
             return (
               <div key={data.id} style={{ display: "flex" }}>
-                <img src={data.img} alt="cloudinary" />
+                <img src={generateImageURL(data)} alt="cloudinary" />
                 {/* <img src={data.img} alt="images" /> */}
                 <Box
                   className="boxMenu"

--- a/client/src/pages/Details.js
+++ b/client/src/pages/Details.js
@@ -35,11 +35,10 @@ function Details() {
         data.title.toLowerCase().includes(search.toLowerCase())
       );
 
-  //cloudinary logic
-  const getCloudinaryURL = (img) => {
-    return `https://res.cloudinary.com/dac1at79b/image/upload/c_fill,w_600/${img}`;
+  const generateImageURL = (img) => {
+    return `https://res.cloudinary.com/dac1at79b/image/upload/c_fill,w_200/`;
   };
-  console.log(getCloudinaryURL());
+  console.log(generateImageURL());
 
   const handleDelete = async (id) => {
     try {
@@ -50,7 +49,6 @@ function Details() {
     }
   };
 
-  //using URL as state
   const navigateToEdit = (id) => {
     navigate(`/edit/${id}`);
   };
@@ -78,8 +76,8 @@ function Details() {
           {filteredMenuItems.map((data) => {
             return (
               <div key={data.id} style={{ display: "flex" }}>
-                <img src={getCloudinaryURL(data.img)} alt="cloudinary" />
-                <img src={data.img} alt="images" />
+                <img src={data.img} alt="cloudinary" />
+                {/* <img src={data.img} alt="images" /> */}
                 <Box
                   className="boxMenu"
                   lg={{


### PR DESCRIPTION
Updated all images dimensions using Cloudinary Gravity - Working backwards to update the dimensions for the images , "Closes https://github.com/twentymurial33/murials_menu/issues/107"

- Ensure that all the images are stored in Prisma and Cloudinary because Cloudinary gravity makes a call and fetches from Cloudinary.

<img width="1437" alt="Screen Shot 2023-04-12 at 7 34 53 PM" src="https://user-images.githubusercontent.com/34128735/231608634-7b73d661-ac73-45a0-b731-20f855f8b1ea.png">
<img width="1381" alt="image" src="https://user-images.githubusercontent.com/34128735/231608661-4eb5c956-c217-4c89-a0e1-0a14ae2740de.png">
